### PR TITLE
travis local redis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: scala
+
 sudo: true
+
 scala:
 - 2.11.6
+
 jdk:
 - oraclejdk8
+
 install: true
+
+services:
+- redis-server
+
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
Added redis as an internal Travis service so that test servers use their own redis databases, instead of a shared database. We should now be able to run the test suite concurrently across multiple machines.